### PR TITLE
add biojs.io examples to angularplasmid

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 bower_components/
 node_modules/
+dist/plasmid_browserify.js

--- a/examples/HSP70.html
+++ b/examples/HSP70.html
@@ -1,0 +1,62 @@
+<plasmid sequencelength="360" plasmidheight="375" plasmidwidth="375" xxfilter="url(#dropshadow)">
+    <plasmidtrack trackstyle="fill:#ccc" width="5" radius="110"></plasmidtrack>
+    <plasmidtrack trackstyle="fill:rgba(225,225,225,0.5)" radius="110">
+        <tracklabel text="HSP70" labelstyle='font-size:20px;font-weight:400'></tracklabel>
+        <tracklabel text="360 bp" labelstyle='font-size:10px' vadjust="20"></tracklabel>
+        <trackmarker start="50" end="95" markerstyle="fill:rgba(255,221,238,0.4)" wadjust="-5" vadjust="25"></trackmarker>
+        <trackmarker start="120" end="190" markerstyle="fill:rgba(238,221,255,0.4)" wadjust="-5" vadjust="25"></trackmarker>
+        <trackmarker start="200" end="230" markerstyle="fill:rgba(221,238,255,0.4)" wadjust="-5" vadjust="25"></trackmarker>
+        <trackmarker start="250" end="300" markerstyle="fill:rgba(238,255,221,0.4)" wadjust="-5" vadjust="25"></trackmarker>
+        <trackmarker start="325" end="345" markerstyle="fill:rgba(255,238,221,0.4)" wadjust="-5" vadjust="25"></trackmarker>
+
+        <trackmarker start="50" end="95" markerstyle="fill:rgba(170,0,85,0.9)" arrowendlength="4" arrowstartlength="-4">
+            <markerlabel type="path" labelstyle="font-size:12px;fill:#fff;font-weight:400" text="HSP70"></markerlabel>
+        </trackmarker>
+        <trackmarker start="120" end="190" markerstyle="fill:rgba(85,0,170,0.9)" arrowendlength="4" arrowstartlength="-4">
+            <markerlabel type="path" labelstyle="font-size:12px;fill:#fff;font-weight:400" text="NF1 Promoter"></markerlabel>
+        </trackmarker>
+        <trackmarker start="200" end="230" markerstyle="fill:rgba(0,85,170,0.9)" arrowendlength="4" arrowstartlength="-4">
+            <markerlabel type="path" labelstyle="font-size:12px;fill:#fff;font-weight:400" text="Sig"></markerlabel>
+        </trackmarker>
+        <trackmarker start="250" end="300" markerstyle="fill:rgba(85,170,0,0.9)" arrowendlength="4" arrowstartlength="-4">
+            <markerlabel type="path" labelstyle="font-size:12px;fill:#fff;font-weight:400" text="ColE1 Ori"></markerlabel>
+        </trackmarker>
+        <trackmarker start="325" end="345" markerstyle="fill:rgba(170,85,0,0.9)" arrowendlength="4" arrowstartlength="-4">
+            <markerlabel type="path" labelstyle="font-size:12px;fill:#fff;font-weight:400" text="P3"></markerlabel>
+        </trackmarker>
+
+        <trackmarker start="50" markerstyle="stroke:rgba(128,64,64,0.8);stroke-dasharray:2,2;stroke-width:2px" wadjust="20">
+            <markerlabel labelstyle="font-size:8px;font-weight:400;fill:rgb(192,64,64)" text="50" vadjust="30"></markerlabel>
+        </trackmarker>
+        <trackmarker start="95" markerstyle="stroke:rgba(128,64,64,0.8);stroke-dasharray:2,2;stroke-width:2px" wadjust="20">
+            <markerlabel labelstyle="font-size:8px;font-weight:400;fill:rgb(192,64,64)" text="95" vadjust="30"></markerlabel>
+        </trackmarker>
+        <trackmarker start="120" markerstyle="stroke:rgba(128,64,128,0.8);stroke-dasharray:2,2;stroke-width:2px" wadjust="20">
+            <markerlabel labelstyle="font-size:8px;font-weight:400;fill:rgb(192,64,192)" text="120" vadjust="30"></markerlabel>
+        </trackmarker>
+        <trackmarker start="190" markerstyle="stroke:rgba(128,64,128,0.8);stroke-dasharray:2,2;stroke-width:2px" wadjust="20">
+            <markerlabel labelstyle="font-size:8px;font-weight:400;fill:rgb(192,64,192)" text="190" vadjust="30"></markerlabel>
+        </trackmarker>
+        <trackmarker start="200" markerstyle="stroke:rgba(64,128,128,0.8);stroke-dasharray:2,2;stroke-width:2px" wadjust="20">
+            <markerlabel labelstyle="font-size:8px;font-weight:400;fill:rgb(64,192,192)" text="200" vadjust="30"></markerlabel>
+        </trackmarker>
+        <trackmarker start="230" markerstyle="stroke:rgba(64,128,128,0.8);stroke-dasharray:2,2;stroke-width:2px" wadjust="20">
+            <markerlabel labelstyle="font-size:8px;font-weight:400;fill:rgb(64,192,192)" text="230" vadjust="35"></markerlabel>
+        </trackmarker>
+        <trackmarker start="250" markerstyle="stroke:rgba(64,128,64,0.8);stroke-dasharray:2,2;stroke-width:2px" wadjust="20">
+            <markerlabel labelstyle="font-size:8px;font-weight:400;fill:rgb(64,192,64)" text="250" vadjust="30"></markerlabel>
+        </trackmarker>
+        <trackmarker start="300" markerstyle="stroke:rgba(64,128,64,0.8);stroke-dasharray:2,2;stroke-width:2px" wadjust="20">
+            <markerlabel labelstyle="font-size:8px;font-weight:400;fill:rgb(64,192,64)" text="300" vadjust="30"></markerlabel>
+        </trackmarker>
+        <trackmarker start="325" markerstyle="stroke:rgba(128,128,64,0.8);stroke-dasharray:2,2;stroke-width:2px" wadjust="20">
+            <markerlabel labelstyle="font-size:8px;font-weight:400;fill:rgb(192,128,64)" text="325" vadjust="30"></markerlabel>
+        </trackmarker>
+        <trackmarker start="345" markerstyle="stroke:rgba(128,128,64,0.8);stroke-dasharray:2,2;stroke-width:2px" wadjust="20">
+            <markerlabel labelstyle="font-size:8px;font-weight:400;fill:rgb(192,128,64)" text="345" vadjust="30"></markerlabel>
+        </trackmarker>
+
+        <trackscale interval="5" style='stroke:#999' direction="in" ticksize="3"></trackscale>
+        <trackscale interval="5" style='stroke:#999' ticksize="3"></trackscale>
+        <trackscale interval="30" style="stroke:#f00" direction="in" showlabels="1" labelstyle="fill:#999;stroke:none;text-anchor:middle;alignment-baseline:middle;font-size:10px"></trackscale>
+    </plasmidtrack>

--- a/examples/HSP70.js
+++ b/examples/HSP70.js
@@ -1,0 +1,2 @@
+
+var plasmid = require("angularplasmid");

--- a/examples/first.html
+++ b/examples/first.html
@@ -1,0 +1,43 @@
+<style>
+    #p1 {
+        border: 1px solid #ccc
+    }
+    #t1 {
+        fill: #f0f0f0;
+        stroke: #ccc
+    }
+    .sminor {
+        stroke: #ccc
+    }
+    .smajor {
+        stroke: #f00
+    }
+    .sml {
+        fill: #999;
+        font-size: 10px
+    }
+    .smajorin {
+        stroke: #999
+    }
+    .marker {
+        fill: #fc0;
+        stroke: #fc0
+    }
+    .mlabel {
+        fill: #c00;
+        font-size: 10px;
+        font-weight: bold
+    }
+</style>
+<plasmid id='p1' sequencelength='1000'>
+    <plasmidtrack id='t1'>
+        <trackscale class='sminor' interval='10'></trackscale>
+        <trackscale class='smajor' interval='50' showlabels='1' labelclass='sml'></trackscale>
+        <trackscale class='smajorin' interval='50' direction='in'></trackscale>
+        <trackmarker class='marker' start='50' end='250'>
+            <markerlabel class='mlabel' text='SAMPLE' type='path'></markerlabel>
+            <markerlabel class='mlabel' text='Inner' vadjust='-40'></markerlabel>
+            <markerlabel class='mlabel' text='OUTER' type='path' vadjust='55'></markerlabel>
+        </trackmarker>
+    </plasmidtrack>
+</plasmid>

--- a/examples/first.js
+++ b/examples/first.js
@@ -1,0 +1,1 @@
+var plasmid = require("angularplasmid");

--- a/examples/intermediate.html
+++ b/examples/intermediate.html
@@ -1,0 +1,10 @@
+<plasmid sequencelength='1000'>
+    <plasmidtrack radius='75' style='fill:#f0f0f0;stroke:#ccc'>
+        <trackmarker ng-repeat='n in [50,90,130,200,350,400,450,600,735,900]' start='{{n}}' end='{{n+20}}' style='fill:#9cf;stroke:#036'>
+            <markerlabel text='Pos [{{n}}]' vadjust='35' style='font-size:10px'></markerlabel>
+        </trackmarker>
+        <tracklabel text='pBR1' style='font-size:25px;font-weight:bold'></tracklabel>
+        <trackscale interval='10' direction='in' style='stroke:#ccc'></trackscale>
+        <trackscale interval='100' direction='in' showlabels='1' style='stroke:#f00;stroke-width:2p' labelvadjust='10' labelstyle='font-size:8px;fill:#999'></trackscale>
+    </plasmidtrack>
+</plasmid>

--- a/examples/intermediate.js
+++ b/examples/intermediate.js
@@ -1,0 +1,1 @@
+var plasmid = require("angularplasmid");

--- a/examples/pBCA-RLuc.html
+++ b/examples/pBCA-RLuc.html
@@ -1,0 +1,39 @@
+<plasmid sequencelength="130" plasmidheight="375" plasmidwidth="375">
+    <plasmidtrack trackstyle="fill:none;stroke:none" radius="110">
+        <tracklabel labelstyle="font-weight:700;fill:#369" text="pBCA-RLuc"></tracklabel>
+        <tracklabel labelstyle="font-size:14px;font-weight:300;fill:#036" text="130 bp" vadjust="20"></tracklabel>
+        <trackscale interval="5" style='stroke:#999' labelstyle='fill:#999;font-size:8px' labelvadjust="12" showlabels="1"></trackscale>
+        <trackmarker start="50" end="75" markerstyle="stroke:rgba(192,64,64,0.4);fill:rgba(255,192,192,0.4)" vadjust="-6" wadjust="5"></trackmarker>
+        <trackmarker start="85" end="100" markerstyle="stroke:rgba(64,192,64,0.4);fill:rgba(192,255,192,0.4)" vadjust="-6" wadjust="5"></trackmarker>
+        <trackmarker start="120" end="30" markerstyle="stroke:rgba(64,64,192,0.4);fill:rgba(192,192,255,0.4)" vadjust="-6" wadjust="5">
+            <markerlabel type="path" text="Initiating ATG" valign="inner" labelstyle="font-size:10px;fill:#039;font-weight:400" vadjust="-15"></markerlabel>
+        </trackmarker>
+        <trackmarker start="120" end="30" markerstyle="fill:#339" vadjust="-15" wadjust="-23" arrowendlength="5" arrowendwidth="3"></trackmarker>
+        <trackmarker start="0" end="130">
+            <markerlabel type="path" labelstyle="font-size:8px;font-weight:400;kerning:1.1" text="GGAAAAGGAGGCCAGTGCATCAGAGAGACGCTGAAACTGTATGCGGAAAAGGAGGCCAGTGCATCAGAGAGTCGCAAACAGCTGTGAAGTCGCGTTCTCAAGAATTTGCAGCAGGCTGTGGCCACTTCGCCGGAAAAGGAGGCCAGTGCATCAGAGAGCAAGATCACAGCTGTGAAGTCGCTTC" halign="start" vadjust="5"></markerlabel>
+            <markerlabel type="path" labelstyle="font-size:8px;font-weight:400" text="CCTTTTCCTCCGGTCACGTAGTCTCTCTGCGACTTTGACATACGCCTTTTCCTCCGGTCACGTAGTCTCTCAGCGTTTGTCGACACTTCAGCGCAAGAGTTCTTAAACGTCGTCCGACACCGGTGAAGCGGCCTTTTCCTCCGGTCACGTAGTCTCTCGTTCTAGTGTCGACACTTCAGCGAAG" halign="start" vadjust="-10"></markerlabel>
+        </trackmarker>
+        <trackmarker start="62" end="82" markerstyle="fill:#939" vadjust="-15" wadjust="-23" arrowendlength="5" arrowendwidth="3">
+            <markerlabel text="82" halign="end" vadjust="-10" labelstyle="font-size:10px;fill:#939"></markerlabel>
+        </trackmarker>
+        <trackmarker start="55" end="72" markerstyle="fill:#939" vadjust="-20" wadjust="-23" arrowstartlength="5" arrowstartwidth="3">
+            <markerlabel text="55" halign="start" vadjust="-10" labelstyle="font-size:10px;fill:#939"></markerlabel>
+        </trackmarker>
+        <trackmarker start="55" end="82" markerstyle="stroke:none;fill:none" vadjust="-20" wadjust="-23">
+            <markerlabel text="Promoter" vadjust="-15" labelstyle="font-size:10px;fill:#939;font-weight:400"></markerlabel>
+        </trackmarker>
+        <trackmarker start="112" markerstyle="stroke:rgba(255,0,0,1);stroke-width:2px" vadjust="-6" wadjust="5">
+            <markerlabel text="HindIII" labelstyle="fill:#f00;font-size:10px;font-weight:400" valign="inner" vadjust="-20"></markerlabel>
+            <markerlabel text="112" labelstyle="fill:#f00;font-size:10px;font-weight:400" valign="outer" vadjust="15"></markerlabel>
+        </trackmarker>
+        <trackmarker start="38" markerstyle="stroke:rgba(255,0,0,1);stroke-width:2px" vadjust="-6" wadjust="5">
+            <markerlabel text="HindIII" labelstyle="fill:#f00;font-size:10px;font-weight:400" valign="inner" vadjust="-20"></markerlabel>
+            <markerlabel text="38" labelstyle="fill:#f00;font-size:10px;font-weight:400" valign="outer" vadjust="15"></markerlabel>
+        </trackmarker>
+        <trackmarker start="87" markerstyle="stroke:rgba(255,0,0,1);stroke-width:2px" vadjust="-6" wadjust="5">
+            <markerlabel text="HindIII" labelstyle="fill:#f00;font-size:10px;font-weight:400" valign="inner" vadjust="-20"></markerlabel>
+            <markerlabel text="87" labelstyle="fill:#f00;font-size:10px;font-weight:400" valign="outer" vadjust="15"></markerlabel>
+        </trackmarker>
+        <trackscale interval="1" style='stroke:#c99' ticksize="5" vadjust="-18"></trackscale>
+    </plasmidtrack>
+</plasmid>

--- a/examples/pBCA-RLuc.js
+++ b/examples/pBCA-RLuc.js
@@ -1,0 +1,1 @@
+var plasmid = require("angularplasmid");

--- a/examples/pBR322.html
+++ b/examples/pBR322.html
@@ -1,0 +1,49 @@
+<plasmid sequencelength="1000" plasmidheight="375" plasmidwidth="375">
+    <plasmidtrack trackstyle="fill:#f0f0f0;stroke:#009;filter:url(#dropshadow)" width="35" radius="63">
+        <tracklabel text="pBR322" labelstyle="fill:#900;font-weight:700;filter:url(#dropshadow)"></tracklabel>
+        <trackmarker start="100" end="250" markerstyle="fill:rgb(32,32,64)">
+            <markerlabel type="path" labelstyle="fill:#fff;font-size:12px;font-weight:400" text="pUC ORI"></markerlabel>
+        </trackmarker>
+        <trackmarker start="250" end="440" markerstyle="fill:rgb(64,64,128)">
+            <markerlabel type="path" labelstyle="fill:#fff;font-size:12px;font-weight:400" text="hPGK"></markerlabel>
+        </trackmarker>
+        <trackmarker start="440" end="620" markerstyle="fill:rgb(92,92,164)">
+            <markerlabel type="path" labelstyle="fill:#fff;font-size:12px;font-weight:400" text="ORI"></markerlabel>
+        </trackmarker>
+        <trackmarker start="620" end="800" markerstyle="fill:rgb(128,128,192)">
+            <markerlabel type="path" labelstyle="fill:#fff;font-size:12px;font-weight:400" text="AraC"></markerlabel>
+        </trackmarker>
+        <trackmarker start="800" end="975" markerstyle="fill:rgb(192,192,225)">
+            <markerlabel type="path" labelstyle="fill:#000;font-size:12px;font-weight:400" text="Ampf"></markerlabel>
+        </trackmarker>
+        <trackmarker start="975" end="100" markerstyle="fill:rgb(225,225,255)">
+            <markerlabel type="path" labelstyle="fill:#000;font-size:12px;font-weight:400" text="GFP"></markerlabel>
+        </trackmarker>
+        <trackscale interval="50" style="stroke:#c00;stroke-width:2px" vadjust="5" ticksize="4"></trackscale>
+        <trackscale interval="10" style="stroke:#999;stroke-width:1px" vadjust="5"></trackscale>
+        <trackscale interval="50" style="stroke:#c00;stroke-width:2px" ticksize="4" direction="in"></trackscale>
+        <trackscale interval="10" style="stroke:#999;stroke-width:1px" direction="in"></trackscale>
+    </plasmidtrack>
+    <plasmidtrack trackstyle="fill:#f0f0f0;stroke:#999;stroke:#333;filter:url(#dropshadow)" width="20" radius="{{(sample.size/4)+15}}">
+        <trackmarker start="100" end="250" markerstyle="fill:rgb(64,64,64)">
+            <markerlabel type="path" labelstyle="fill:#fff;font-size:10px;font-weight:700" text="LacZ"></markerlabel>
+        </trackmarker>
+        <trackmarker start="250" end="440" markerstyle="fill:rgb(92,92,92)">
+            <markerlabel type="path" labelstyle="fill:#fff;font-size:10px;font-weight:700" text="nat-1"></markerlabel>
+        </trackmarker>
+        <trackmarker start="440" end="620" markerstyle="fill:rgb(128,128,128)">
+            <markerlabel type="path" labelstyle="fill:#fff;font-size:10px;font-weight:700" text="SacB#3"></markerlabel>
+        </trackmarker>
+        <trackmarker start="620" end="800" markerstyle="fill:rgb(192,192,192)">
+            <markerlabel type="path" labelstyle="fill:#fff;font-size:10px;font-weight:700" text="Tn7R"></markerlabel>
+        </trackmarker>
+        <trackmarker start="800" end="975" markerstyle="fill:rgb(225,225,225)">
+            <markerlabel type="path" labelstyle="fill:#000;font-size:10px;font-weight:700" text="SV40 pA"></markerlabel>
+        </trackmarker>
+        <trackmarker start="975" end="100" markerstyle="fill:rgb(252,252,252)">
+            <markerlabel type="path" labelstyle="fill:#000;font-size:10px;font-weight:700" text="Tn7L"></markerlabel>
+        </trackmarker>
+        <trackscale interval="50" style="stroke:#c00;stroke-width:2px" vadjust="5" ticksize="4" showlabels="1" labelstyle="font-size:10px;font-weight:400;fill:#999"></trackscale>
+        <trackscale interval="10" style="stroke:#999;stroke-width:1px" vadjust="5"></trackscale>
+    </plasmidtrack>
+</plasmid>

--- a/examples/pBR322.js
+++ b/examples/pBR322.js
@@ -1,0 +1,1 @@
+var plasmid = require("angularplasmid");

--- a/examples/pLVG440.html
+++ b/examples/pLVG440.html
@@ -1,0 +1,48 @@
+<plasmid sequencelength="7500" plasmidheight="375" plasmidwidth="375">
+    <plasmidtrack width="5" radius='110'>
+        <tracklabel labelstyle="font-size:18px;font-weight:700" text="pLVG440"></tracklabel>
+        <tracklabel labelstyle="font-size:10px;font-weight:300" vadjust="20" text="7500 bp"></tracklabel>
+        <trackmarker start="1607" end="3100" wadjust="15" vadjust="15" markerstyle="fill:none;stroke:#000;stroke-width:2px">
+            <markerlabel type="path" text="ORF 3" labelstyle="font-size:10px;font-weight:400"></markerlabel>
+        </trackmarker>
+        <trackmarker start="2940" end="3050" wadjust="10" vadjust="18" markerstyle="fill:none;stroke:#000;stroke-width:2px;" arrowendlength="5"></trackmarker>
+        <trackmarker start="3100" end="4200" wadjust="15" vadjust="15" markerstyle="fill:none;stroke:#000;stroke-width:2px">
+            <markerlabel type="path" text="ORF 4" labelstyle="font-size:10px;font-weight:400"></markerlabel>
+        </trackmarker>
+        <trackmarker start="4040" end="4150" wadjust="10" vadjust="18" markerstyle="fill:none;stroke:#000;stroke-width:2px;" arrowendlength="5"></trackmarker>
+        <trackmarker start="4500" end="5200" wadjust="15" vadjust="15" markerstyle="fill:none;stroke:#000;stroke-width:2px">
+            <markerlabel type="path" text="ORF 5" labelstyle="font-size:10px;font-weight:400"></markerlabel>
+        </trackmarker>
+        <trackmarker start="5040" end="5150" wadjust="10" vadjust="18" markerstyle="fill:none;stroke:#000;stroke-width:2px;" arrowendlength="5"></trackmarker>
+        <trackmarker start="5300" end="6200" wadjust="15" vadjust="15" markerstyle="fill:none;stroke:#000;stroke-width:2px">
+            <markerlabel type="path" text="ORF 6" labelstyle="font-size:10px;font-weight:400"></markerlabel>
+        </trackmarker>
+        <trackmarker start="6040" end="6150" wadjust="10" vadjust="18" markerstyle="fill:none;stroke:#000;stroke-width:2px;" arrowendlength="5"></trackmarker>
+        <trackmarker start="6200" end="7400" wadjust="15" vadjust="15" markerstyle="fill:none;stroke:#000;stroke-width:2px">
+            <markerlabel type="path" text="ORF 7" labelstyle="font-size:10px;font-weight:400"></markerlabel>
+        </trackmarker>
+        <trackmarker start="7240" end="7350" wadjust="10" vadjust="18" markerstyle="fill:none;stroke:#000;stroke-width:2px;" arrowendlength="5"></trackmarker>
+        <trackmarker start="520" end="1600" wadjust="15" vadjust="-30" markerstyle="fill:none;stroke:#000;stroke-width:2px">
+            <markerlabel type="path" text="ORF 2" labelstyle="font-size:10px;font-weight:400"></markerlabel>
+        </trackmarker>
+        <trackmarker start="570" end="700" wadjust="10" vadjust="-28" markerstyle="fill:none;stroke:#000;stroke-width:2px;" arrowstartlength="6"></trackmarker>
+        <trackmarker start="570" wadjust="12" vadjust="-6" markerstyle="stroke:#000;stroke-width:3px;">
+            <markerlabel text="Bgl II" labelstyle="font-size:10px;font-weight:bold" vadjust="20"></markerlabel>
+        </trackmarker>
+        <trackmarker start="995" wadjust="12" vadjust="-6" markerstyle="stroke:#000;stroke-width:3px;">
+            <markerlabel text="Sma I" labelstyle="font-size:10px;font-weight:bold" vadjust="20"></markerlabel>
+        </trackmarker>
+        <trackmarker start="2493" wadjust="12" vadjust="-6" markerstyle="stroke:#000;stroke-width:3px;">
+            <markerlabel text="Pst I" labelstyle="font-size:10px;font-weight:bold" vadjust="-20"></markerlabel>
+        </trackmarker>
+        <trackmarker start="3222" wadjust="12" vadjust="-6" markerstyle="stroke:#000;stroke-width:3px;">
+            <markerlabel text="EcoRI" labelstyle="font-size:10px;font-weight:bold" vadjust="-20"></markerlabel>
+        </trackmarker>
+        <trackmarker start="4556" wadjust="12" vadjust="-6" markerstyle="stroke:#000;stroke-width:3px;">
+            <markerlabel text="Dra II" labelstyle="font-size:10px;font-weight:bold" vadjust="-25"></markerlabel>
+        </trackmarker>
+        <trackmarker start="6155" wadjust="12" vadjust="-6" markerstyle="stroke:#000;stroke-width:3px;">
+            <markerlabel text="EcoRI" labelstyle="font-size:10px;font-weight:bold" vadjust="-25"></markerlabel>
+        </trackmarker>
+    </plasmidtrack>
+</plasmid>

--- a/examples/pLVG440.js
+++ b/examples/pLVG440.js
@@ -1,0 +1,1 @@
+var plasmid = require("angularplasmid");

--- a/examples/pPMA43C.html
+++ b/examples/pPMA43C.html
@@ -1,0 +1,41 @@
+<plasmid sequencelength="1000" plasmidheight="375" plasmidwidth="375">
+    <plasmidtrack width="5" trackstyle='fill:#ccc;stroke:#999;filter:url(#dropshadow)' radius='125'>
+        <tracklabel labelstyle="font-size:20px;font-weight:700;fill:#666;filter:url(#dropshadow)" text="pPMA43C"></tracklabel>
+        <tracklabel labelstyle="font-size:12px;font-weight:400;fill:#999;filter:url(#dropshadow)" text="1,000 bp" vadjust="18"></tracklabel>
+        <trackscale interval="10" style="stroke:#999;" vadjust="8"></trackscale>
+        <trackscale interval="50" showlabels="1" style="stroke:#333;stroke-width:2px" ticksize="5" vadjust="8" labelstyle="font-size:9px;fill:#666" labelvadjust="15"></trackscale>
+        <trackmarker start="200" end="330" markerstyle='stroke:#000;fill:#ff0;filter:url(#dropshadow)' arrowstartlength="10" arrowstartwidth="5" wadjust="10" vadjust="-5">
+            <markerlabel text="PstI" vadjust="40" hadjust="2" valign="outer" style="font-size:14px;font-weight:400;fill:#990" showline="1" linevadjust="-15" linevadjust="-15" linelabelstyle="stroke:#cc0;stroke-dasharray:2,2;stroke-width:2px;"></markerlabel>
+            <markerlabel type="path" text="200-330" labelstyle="font-size:8px;font-weight:400;fill:#990"></markerlabel>
+        </trackmarker>
+        <trackmarker start="450" end="620" markerstyle='stroke:#000;fill:#f00;filter:url(#dropshadow)' arrowendlength="10" arrowendwidth="5" wadjust="10" vadjust="-5">
+            <markerlabel text="AcolIII" vadjust="40" hadjust="2" valign="outer" style="font-size:14px;font-weight:400;fill:#c00" showline="1" linevadjust="-10" linelabelstyle="stroke:#c00;stroke-dasharray:2,2;stroke-width:2px;"></markerlabel>
+            <markerlabel type="path" text="400-620" labelstyle="font-size:8px;font-weight:400;fill:#fff0f0"></markerlabel>
+        </trackmarker>
+        <trackmarker start="630" end="720" markerstyle='stroke:#000;fill:#f00;filter:url(#dropshadow)' arrowendlength="10" arrowendwidth="5" wadjust="10" vadjust="-5">
+            <markerlabel text="EcoRI" vadjust="40" hadjust="-2" valign="outer" style="font-size:14px;font-weight:400;fill:#c00" showline="1" linevadjust="-20" linelabelstyle="stroke:#c00;stroke-dasharray:2,2;stroke-width:2px;"></markerlabel>
+            <markerlabel type="path" text="630-720" labelstyle="font-size:8px;font-weight:400;fill:#fff0f0"></markerlabel>
+        </trackmarker>
+        <trackmarker start="760" end="880" markerstyle='stroke:#000;fill:#0f0;filter:url(#dropshadow)' arrowendlength="10" arrowendwidth="5" wadjust="10" vadjust="-5">
+            <markerlabel text="ScaI" vadjust="40" valign="outer" style="font-size:14px;font-weight:400;fill:#0c0" showline="1" linevadjust="-15" linelabelstyle="stroke:#0c0;stroke-dasharray:2,2;stroke-width:2px;"></markerlabel>
+            <markerlabel type="path" text="760-880" labelstyle="font-size:8px;font-weight:400;fill:#060"></markerlabel>
+        </trackmarker>
+        <trackmarker start="980" end="150" markerstyle='stroke:#000;fill:#00f;filter:url(#dropshadow)' wadjust="10" vadjust="-5">
+            <markerlabel text="TaqI" vadjust="40" hadjust="2" valign="outer" style="font-size:14px;font-weight:400;fill:#00c" showline="1" linevadjust="-10" linevadjust="-15" linelabelstyle="stroke:#00c;stroke-dasharray:2,2;stroke-width:2px;"></markerlabel>
+            <markerlabel type="path" text="920-150" labelstyle="font-size:8px;font-weight:400;fill:#f0f0ff"></markerlabel>
+        </trackmarker>
+
+        <trackmarker start="420" end="430" markerstyle='stroke:#000;fill:#666' wadjust="20" vadjust="-10">
+            <markerlabel text="A35" vadjust="-15" valign="inner" labelstyle="font-size:10px;font-weight:400;fill:#999"></markerlabel>
+        </trackmarker>
+        <trackmarker start="355" end="365" markerstyle='stroke:#000;fill:#666' wadjust="20" vadjust="-10">
+            <markerlabel text="A36" vadjust="-15" valign="inner" labelstyle="font-size:10px;font-weight:400;fill:#999"></markerlabel>
+        </trackmarker>
+        <trackmarker start="905" end="915" markerstyle='stroke:#000;fill:#666' wadjust="20" vadjust="-10">
+            <markerlabel text="A22" vadjust="-15" valign="inner" labelstyle="font-size:10px;font-weight:400;fill:#999"></markerlabel>
+        </trackmarker>
+        <trackmarker start="170" end="180" markerstyle='stroke:#000;fill:#666' wadjust="20" vadjust="-10">
+            <markerlabel text="A14" vadjust="-15" valign="inner" labelstyle="font-size:10px;font-weight:400;fill:#999"></markerlabel>
+        </trackmarker>
+    </plasmidtrack>
+</plasmid>

--- a/examples/pPMA43C.js
+++ b/examples/pPMA43C.js
@@ -1,0 +1,1 @@
+var plasmid = require("angularplasmid");

--- a/examples/pUC19.html
+++ b/examples/pUC19.html
@@ -1,0 +1,20 @@
+<plasmid sequencelength="2686" plasmidheight="375" plasmidwidth="375">
+    <plasmidtrack trackstyle="fill:#c60;stroke:none" radius="125" width="8">
+        <tracklabel text="pUC19" labelstyle="font-size:30px;font-weight:700"></tracklabel>
+        <tracklabel text="2686 bp" labelstyle="font-size:18px;font-weight:400" vadjust="25"></tracklabel>
+        <trackmarker start="80" end="454" arrowstartlength="10" arrowstartwidth="5" arrowstartangle="3" vadjust="-10">
+            <markerlabel text="lacZ" vadjust="-30" labelstyle="font-weight:400;font-size:20px"></markerlabel>
+        </trackmarker>
+        <trackmarker start="396" end="454" vadjust="-10" markerstyle="fill:#00f">
+            <markerlabel text="Polylinker" vadjust="-35" labelstyle="font-weight:400;font-size:16px;fill:#00f"></markerlabel>
+            <markerlabel text="396-454" vadjust="40" labelstyle="font-weight:400;font-size:14px;fill:#00f"></markerlabel>
+        </trackmarker>
+        <trackmarker start="800" end="1400" arrowstartlength="10" arrowstartwidth="5" arrowstartangle="3" vadjust="-10">
+            <markerlabel text="ori" vadjust="-25" labelstyle="font-weight:400;font-size:20px"></markerlabel>
+        </trackmarker>
+        <trackmarker start="1700" end="2500" arrowstartlength="10" arrowstartwidth="5" arrowstartangle="3" vadjust="-10">
+            <markerlabel text="amp" vadjust="-30" labelstyle="font-weight:400;font-size:20px"></markerlabel>
+        </trackmarker>
+        <trackscale interval="500" labelvadjust="20" showlabels="1" labelstyle="font-size:12px"></trackscale>
+    </plasmidtrack>
+</plasmid>

--- a/examples/pUC19.js
+++ b/examples/pUC19.js
@@ -1,0 +1,1 @@
+var plasmid = require("angularplasmid");

--- a/index.js
+++ b/index.js
@@ -1,0 +1,6 @@
+// this is a quick & dirty way to bundle this package with NPM
+var angular = require("angular");
+require("./src/js/declare.js");
+require("./src/js/services.js");
+require("./src/js/directives.js");
+require("./src/js/init.js");

--- a/package.json
+++ b/package.json
@@ -1,10 +1,11 @@
 {
-  "name": "AngularPlasmid",
+  "name": "angularplasmid",
   "version": "0.0.1",
   "description": "Biological Plasmid Visualization Component using AngularJS",
-  "main": "gulpfile.js",
+  "main": "index.js",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "echo \"Error: no test specified\" && exit 1",
+    "build": "browserify -r ./:angularplasmid -d > dist/plasmid_browserify.js"
   },
   "repository": {
     "type": "git",
@@ -17,9 +18,21 @@
   },
   "homepage": "https://github.com/vixis/angularplasmid",
   "devDependencies": {
+    "browserify": "^8.1.3",
     "del": "^0.1.1",
     "gulp": "^3.8.7",
     "gulp-concat": "^2.3.4",
     "gulp-uglify": "^0.3.1"
+  },
+  "sniper": {
+    "first": "first",
+    "js": [
+      "dist/plasmid_browserify.js"
+    ],
+    "buildJS": []
+  },
+  "keywords": ["biojs", "plasmid"],
+  "dependencies": {
+    "angular": "^1.3.12"
   }
 }


### PR DESCRIPTION
Hey, 

this should add your lovely component to biojs.io
I added all examples from angularplasmid.vixis.com to it.
Maybe you want to change the first plasmid that is shown (property `first`).

The angularjs and [web components](https://github.com/biojs/biojs/issues/144) support is still in progress, but for now this at least creates visibility for your component :)

To test this locally you can run:

```
npm install -g biojs-sniper # tool to simulate the biojs registry

# in your folder
npm install   # downloads the added npm dependencies e.g. angular, browserify 
npm run build # builds the browserified source
```

To simulate the output at the BioJS registry you can run the "sniper" tool with

```
sniper
```

Now browse: http://localhost:9090/examples

To submit the version to the BioJS registry it as easy as

```
npm publish
```

Best,

Seb